### PR TITLE
Sort for Top 5

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ class Covid19 extends utils.Adapter {
 				continentsStats['America'] = {};
 				continentsStats['World_Sum'] = {};
 
-				const result = await request('https://corona.lmao.ninja/countries');
+				const result = await request('https://corona.lmao.ninja/countries?sort=cases');
 				this.log.debug(`Data from COVID-19 API received : ${result}`);
 				this.log.debug(`load all country's : ${this.config.loadAllCountrys} as ${typeof this.config.loadAllCountrys}`);
 				const values = JSON.parse(result);


### PR DESCRIPTION
In der Top 5 Sortierung war China immer noch auf Platz 1, obwohl die eigentlich schon auf Platz 3 abgesunken sind.
Nun ist die Reihenfolge richtig