### PR TITLE
Top 5 ohne World

### DIFF
--- a/main.js
+++ b/main.js
@@ -201,7 +201,7 @@ class Covid19 extends utils.Adapter {
 					// Write Top 5
 					this.log.debug(`Top 5 Countries : ${JSON.stringify(values.slice(0, 5))}`);
 					for (let position = 1; position <= 5; position++) {
-						const dataset = values[position - 1]; // start at 0
+						const dataset = values[position - 0]; // start at 1
 						let country = dataset.country;
 
 						const channelName = `country_Top_5.${position}`;


### PR DESCRIPTION
In die Auflistung der API wurde die Gesamtzahlen der Welt aufgenommen und daher wurde automatisch in den Top 5 die Welt als Platz 1 angezeigt. Und die Top 5 sollten ja eigentlich nur die einzelnen Länder sein.